### PR TITLE
Use BUILD_SHARED_LIBS to select if compile C++ library as static or shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(BUILD_EXAMPLES "Build example programs" ON)
 option(BUILD_PYTHON_MODULE "Build python module" OFF)
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_BENCHMARK "Build benchmark" OFF)
+option(BUILD_SHARED_LIBS "Build as shared library" ON)
 
 
 find_package(Reflexxes)
@@ -22,7 +23,7 @@ else()
 endif()
 
 
-add_library(ruckig SHARED
+add_library(ruckig
   src/brake.cpp
   src/position1.cpp
   src/position2.cpp


### PR DESCRIPTION
The standard [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) CMake variable can be used to control if the library is compiled as STATIC or SHARED. Defining the variable as an option that defaults to ON means that the default behavior remains to compile as shared, while permitting who wants to compile as static. 