### PR TITLE
Add a ROS package manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ install(FILES
   DESTINATION ${ruckig_INSTALL_CONFIGDIR}
 )
 
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/package.xml"
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}
+)
+
 
 if(BUILD_TESTS)
   enable_testing()

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ruckig</name>
+  <version>0.2.0</version>
+  <description>Online Trajectory Generation. Real-time. Time-optimal. Jerk-constrained.</description>
+  <author>Lars Berscheid</author>
+  <maintainer email="lars.berscheid@kit.edu">Lars Berscheid</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
As per subject.

With this, this package is buildable as-is in a Catkin/Colcon workspace -- which are tools typically used to build ROS packages.

The manifest also gets installed into the directory tools like `rosdep` and `rospkg` crawl, so those should be able to detect it as well.
