### PR TITLE
Include GNU install dirs earlier to avoid CMAKE_INSTALL_INCLUDEDIR being empty/undefined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.10)
 project(ruckig VERSION 0.2.0 LANGUAGES CXX)
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+include(GNUInstallDirs)
 
 option(BUILD_EXAMPLES "Build example programs" ON)
 option(BUILD_PYTHON_MODULE "Build python module" OFF)
@@ -77,7 +78,6 @@ endif()
 
 
 # Add support for installation
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # Install headers


### PR DESCRIPTION
`CMAKE_INSTALL_INCLUDEDIR` is used when setting up the `ruckig::ruckig` target here:

https://github.com/pantor/ruckig/blob/d68b71ac7324ad10efffa844093890ba10dca304/CMakeLists.txt#L32-L35

but `GNUInstallDirs` is only included here:

https://github.com/pantor/ruckig/blob/d68b71ac7324ad10efffa844093890ba10dca304/CMakeLists.txt#L79-L80

At least in my workspace (with #10), this causes `INTERFACE_INCLUDE_DIRECTORIES` to be empty when downstream consumers try to `target_link_libraries(.. ruckig::ruckig)`.

I'm not sure whether you want `include(GNUInstallDirs)` where I moved it, but IIUC, it should be before the use of `CMAKE_INSTALL_INCLUDEDIR`.

---

Edit: to clarify: this is with `ruckig` as a stand-alone project, so not as a subdir in another CMake project.
