### PR TITLE
Fix BUILD_PYTHON_MODULE option on Windows/MSVC when BUILD_SHARED_LIBS is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,11 @@ if(BUILD_PYTHON_MODULE)
   pybind11_add_module(python_ruckig src/python.cpp)
   target_compile_features(python_ruckig PUBLIC cxx_std_17)
   target_link_libraries(python_ruckig PUBLIC ruckig)
-  set_target_properties(python_ruckig PROPERTIES OUTPUT_NAME ruckig)
+  if(NOT MSVC)
+    set_target_properties(python_ruckig PROPERTIES OUTPUT_NAME ruckig)
+  else()
+    set_target_properties(python_ruckig PROPERTIES RUNTIME_OUTPUT_NAME ruckig)
+  endif()
 endif()
 
 


### PR DESCRIPTION
When building the Python bindings on Windows, the `python_ruckig` target generate three files: a `.exp`, a `.lib` and a `.dll` .The `.dll` has a special name that avoids its collision with the `ruckig.dll` shared library, but if `OUTPUT_NAME` is simply set to `ruckig`, then the `ruckig.lib` of the `python_ruckig` target has the same name of the `ruckig.lib` of the `ruckig` target, resulting in compilation errors such as:
~~~
C:\src\ruckig\src\velocity-step2.cpp(49,156): warning C4458: declaration of 'aMax' hides class member [C:\src\ruckig\build\ruckig.vcxproj]
C:\src\ruckig\include\ruckig/velocity.hpp(43,12): message : see declaration of 'ruckig::VelocityStep2::aMax' [C:\src\ruckig\build\ruckig.vcxproj]
C:\src\ruckig\src\velocity-step2.cpp(49,156): warning C4458: declaration of 'aMin' hides class member [C:\src\ruckig\build\ruckig.vcxproj]
C:\src\ruckig\include\ruckig/velocity.hpp(43,18): message : see declaration of 'ruckig::VelocityStep2::aMin' [C:\src\ruckig\build\ruckig.vcxproj]
C:\src\ruckig\src\velocity-step2.cpp(49,156): warning C4458: declaration of 'jMax' hides class member [C:\src\ruckig\build\ruckig.vcxproj]
C:\src\ruckig\include\ruckig/velocity.hpp(43,24): message : see declaration of 'ruckig::VelocityStep2::jMax' [C:\src\ruckig\build\ruckig.vcxproj]
  Generating Code...
  Auto build dll exports
     Creating library C:/src/ruckig/build/Release/ruckig.lib and object C:/src/ruckig/build/Release/ruckig.exp
  ruckig.vcxproj -> C:\src\ruckig\build\Release\ruckig.dll
  Building Custom Rule C:/src/ruckig/CMakeLists.txt
  python.cpp
LINK : fatal error LNK1149: output filename matches input filename 'C:\src\ruckig\build\Release\ruckig.lib' [C:\src\ruckig\build\python_ruckig.vcxproj]
~~~

This PR avoids the problem by just setting `RUNTIME_OUTPUT_NAME` (that just change the names of the .dll) when MSVC is used.