### PR TITLE
allow user to force new computation for the same input

### DIFF
--- a/include/ruckig/ruckig.hpp
+++ b/include/ruckig/ruckig.hpp
@@ -73,7 +73,8 @@ public:
     }
 #endif
 
-    void reset_target(){
+    //! Reset the instance (e.g. to force a new calculation in the next update)
+    void reset() {
         current_input_initialized = false;
     }
 

--- a/include/ruckig/ruckig.hpp
+++ b/include/ruckig/ruckig.hpp
@@ -73,6 +73,10 @@ public:
     }
 #endif
 
+    void reset_target(){
+        current_input_initialized = false;
+    }
+
     //! Filter intermediate positions based on a threshold distance for each DoF
     template<class T> using Vector = typename std::conditional<DOFs >= 1, std::array<T, DOFs>, std::vector<T>>::type;
     std::vector<Vector<double>> filter_intermediate_positions(const InputParameter<DOFs>& input, const Vector<double>& threshold_distance) const {

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -156,7 +156,7 @@ limited by velocity, acceleration, and jerk constraints.";
 #endif
         .def_readwrite("delta_time", &Ruckig<DynamicDOFs, true>::delta_time)
         .def_readonly("degrees_of_freedom", &Ruckig<DynamicDOFs, true>::degrees_of_freedom)
-        .def("reset_target", &Ruckig<DynamicDOFs, true>::reset_target)
+        .def("reset", &Ruckig<DynamicDOFs, true>::reset)
         .def("validate_input", &Ruckig<DynamicDOFs, true>::validate_input, "input"_a, "check_current_state_within_limits"_a=false, "check_target_state_within_limits"_a=true)
         .def("calculate", static_cast<Result (Ruckig<DynamicDOFs, true>::*)(const InputParameter<DynamicDOFs>&, Trajectory<DynamicDOFs>&)>(&Ruckig<DynamicDOFs, true>::calculate), "input"_a, "trajectory"_a)
         .def("calculate", static_cast<Result (Ruckig<DynamicDOFs, true>::*)(const InputParameter<DynamicDOFs>&, Trajectory<DynamicDOFs>&, bool&)>(&Ruckig<DynamicDOFs, true>::calculate), "input"_a, "trajectory"_a, "was_interrupted"_a)

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -156,6 +156,7 @@ limited by velocity, acceleration, and jerk constraints.";
 #endif
         .def_readwrite("delta_time", &Ruckig<DynamicDOFs, true>::delta_time)
         .def_readonly("degrees_of_freedom", &Ruckig<DynamicDOFs, true>::degrees_of_freedom)
+        .def("reset_target", &Ruckig<DynamicDOFs, true>::reset_target)
         .def("validate_input", &Ruckig<DynamicDOFs, true>::validate_input, "input"_a, "check_current_state_within_limits"_a=false, "check_target_state_within_limits"_a=true)
         .def("calculate", static_cast<Result (Ruckig<DynamicDOFs, true>::*)(const InputParameter<DynamicDOFs>&, Trajectory<DynamicDOFs>&)>(&Ruckig<DynamicDOFs, true>::calculate), "input"_a, "trajectory"_a)
         .def("calculate", static_cast<Result (Ruckig<DynamicDOFs, true>::*)(const InputParameter<DynamicDOFs>&, Trajectory<DynamicDOFs>&, bool&)>(&Ruckig<DynamicDOFs, true>::calculate), "input"_a, "trajectory"_a, "was_interrupted"_a)


### PR DESCRIPTION
Otherwise sending the same target with non-zero min_duration
multiple times in a control loop will not trigger a new trajectory.
Instead it claims that it already achieved the target.

An alternative way to address the problem is to add a flag to
InputParameter that can force a fresh computation in the next update.

I'm not particularly in love with the proposed solution,
so if you have better ideas I would like to hear them. :)