### PR TITLE
Create debian package via cpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
-
-project(ruckig VERSION 0.10.1 LANGUAGES CXX)
+set(RUCKIG_VERSION 0.10.1)
+project(ruckig VERSION ${RUCKIG_VERSION} LANGUAGES CXX)
 
 
 include(GNUInstallDirs)
@@ -165,3 +165,15 @@ if(BUILD_BENCHMARK)
 
   target_link_libraries(benchmark-target PRIVATE ruckig)
 endif()
+
+# Enable Packaging
+set(CPACK_PACKAGE_VENDOR "Lars Berscheid")
+set(CPACK_GENERATOR "DEB")
+set(CPACK_PACKAGE_VERSION ${RUCKIG_VERSION})
+set(CPACK_SYSTEM_NAME ${CMAKE_HOST_SYSTEM_PROCESSOR})
+
+# Settings for Debian package
+set(CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION}-1)
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Lars Berscheid")
+set(CPACK_DEBIAN_PACKAGE_CONFLICTS "ros-melodic-ruckig, ros-noetic-ruckig, ros-foxy-ruckig, ros-galactic-ruckig, ros-humble-ruckig, ros-rolling-ruckig")
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 make
 ```
 
-To install Ruckig in a system-wide directory, use `(sudo) make install`. An example of using Ruckig in your CMake project is given by `examples/CMakeLists.txt`. However, you can also include Ruckig as a directory within your project and call `add_subdirectory(ruckig)` in your parent `CMakeLists.txt`. To enable the [Cloud API](http://api.ruckig.com/docs) for intermediate waypoints, just pass the `BUILD_CLOUD_CLIENT` flag to CMake.
+To install Ruckig in a system-wide directory, you can either use `(sudo) make install`
+or install it as debian package using cpack by running
+
+```bash
+cpack
+sudo dpkg -i ruckig*.deb
+```
+
+An example of using Ruckig in your CMake project is given by `examples/CMakeLists.txt`. However, you can also include Ruckig as a directory within your project and call `add_subdirectory(ruckig)` in your parent `CMakeLists.txt`. To enable the [Cloud API](http://api.ruckig.com/docs) for intermediate waypoints, just pass the `BUILD_CLOUD_CLIENT` flag to CMake.
 
 Ruckig is also available as a Python module, in particular for development or debugging purposes. The Ruckig *Community Version* can be installed from [PyPI](https://pypi.org/project/ruckig/) via
 ```bash


### PR DESCRIPTION
This PR allows installing ruckig as debian package.
after you build the project you can run cpack to generate the debian package.
Also the debian package should refuse to install when there already is a ruckig version installed via ROS (didnt test this).