### PR TITLE
install headers again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,13 +98,15 @@ endif()
 # Add support for installation
 include(CMakePackageConfigHelpers)
 
+# Install headers
+install(DIRECTORY include/ruckig DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 # Install library
 install(TARGETS ruckig
   EXPORT ${PROJECT_NAME}-targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 # Install CMake config files


### PR DESCRIPTION
fixup 24ae2d79

Actually install headers and do not redundantly add the include dir to the target.

`INCLUDES DESTINATION` flags in `install(TARGETS` define additional paths that are added to the `INTERFACE_INCLUDE_DIRECTORIES`, they do not install files.