### PR TITLE
Install header files and support older versions of Eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,11 @@ install(TARGETS ruckig
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+# Install header files
+file(GLOB HEADERS "include/ruckig/*.hpp")
+install(FILES ${HEADERS}
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ruckig")
+
 # Install CMake config files
 set(ruckig_INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 

--- a/include/ruckig/utils.hpp
+++ b/include/ruckig/utils.hpp
@@ -22,8 +22,8 @@ template<class T, size_t DOFs, size_t SIZE> using StandardSizeVector = typename 
 
 //! Vector data type based on the Eigen matrix type. Eigen needs to be included seperately
 #ifdef EIGEN_VERSION_AT_LEAST
-#if EIGEN_VERSION_AT_LEAST(3,4,0)
-    template<class T, size_t DOFs> using EigenVector = typename std::conditional<DOFs >= 1, Eigen::Vector<T, DOFs>, Eigen::Vector<T, Eigen::Dynamic>>::type;
+#if EIGEN_VERSION_AT_LEAST(3,3,0)
+    template<class T, size_t DOFs> using EigenVector = typename std::conditional<DOFs >= 1, Eigen::Matrix<T, DOFs, 1>, Eigen::Matrix<T, Eigen::Dynamic, 1>>::type;
 #endif
 #endif
 


### PR DESCRIPTION
Opening a PR rather than an issue as the changes are minimal.

Would you consider the two following changes:
- install the headers. I'm not sure how people work with this library but following the source install instructions gives an environment with an .so file and no header file. This makes the lib unusable in C++ in downstream package, unless one use it in a catkin devel environment.
- Using Eigen::Matrix instead of Eigen::Vector makes the lib support older version of Eigen. In this PR, I changed the minimal version to 3.3.0 but I'm sure it would work with earlier version as well. This helps when using the lib on old distrib.