### PR TITLE
Fix out of bound iterator in tests

### DIFF
--- a/include/ruckig/position.hpp
+++ b/include/ruckig/position.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <cassert>
+#include <iterator>
 #include <optional>
 
 
@@ -105,8 +107,11 @@ class PositionSecondOrderStep1 {
     double pd;
 
     // Max 3 valid profiles
-    using ProfileIter = std::array<Profile, 3>::iterator;
-    std::array<Profile, 3> valid_profiles;
+    static constexpr int max_num_valid_profiles = 3;
+    using Profiles =  std::array<Profile, max_num_valid_profiles + 1>;
+    using ProfileIter = Profiles::iterator;
+
+    Profiles valid_profiles;
 
     void time_acc0(ProfileIter& profile, double vMax, double vMin, double aMax, double aMin, bool return_after_found) const;
     void time_none(ProfileIter& profile, double vMax, double vMin, double aMax, double aMin, bool return_after_found) const;
@@ -115,6 +120,7 @@ class PositionSecondOrderStep1 {
     bool time_all_single_step(Profile* profile, double vMax, double vMin, double aMax, double aMin) const;
 
     inline void add_profile(ProfileIter& profile) const {
+        assert(std::next(profile) != this->valid_profiles.end() && "number of valid profiles exceeded");
         const auto prev_profile = profile;
         ++profile;
         profile->set_boundary(*prev_profile);

--- a/include/ruckig/velocity.hpp
+++ b/include/ruckig/velocity.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <cassert>
+#include <iterator>
 #include <optional>
 
 
@@ -28,6 +30,7 @@ class VelocityThirdOrderStep1 {
     bool time_all_single_step(Profile* profile, double aMax, double aMin, double jMax) const;
 
     inline void add_profile(ProfileIter& profile) const {
+        assert(std::next(profile) != valid_profiles.end() && "maximum number of profiles exceeded");
         const auto prev_profile = profile;
         ++profile;
         profile->set_boundary(*prev_profile);

--- a/include/ruckig/velocity.hpp
+++ b/include/ruckig/velocity.hpp
@@ -20,8 +20,11 @@ class VelocityThirdOrderStep1 {
     double vd;
 
     // Max 3 valid profiles
-    using ProfileIter = std::array<Profile, 3>::iterator;
-    std::array<Profile, 3> valid_profiles;
+    static constexpr int max_num_valid_profiles = 3;
+    using Profiles =  std::array<Profile, max_num_valid_profiles + 1>;
+    using ProfileIter = Profiles::iterator;
+
+    Profiles valid_profiles;
 
     void time_acc0(ProfileIter& profile, double aMax, double aMin, double jMax, bool return_after_found) const;
     void time_none(ProfileIter& profile, double aMax, double aMin, double jMax, bool return_after_found) const;


### PR DESCRIPTION
Hi everyone,

I was trying to build Ruckig w/ tests in Debug and got out-of-bound iterator access errors from some of the tests in
`inline void add_profile(ProfileIter& profile)` in a couple of places that was captured by asserts in STL. 

It looks like the issue is with reserving `std::array<Profile, 3>` being the size of 3, while the `profile` iterator can advance by three from `valid_profiles.begin()` and point to `valid_profiles.end()` when being dereferenced eventually.

I summarize these behavior in a couple of commits. It would be also nice to add an input validation into `add_profile` to fail early in Debug (should be stripped out in Release anyway).

Environment:  Visual Studio Community 2022 Release - x86_amd64; MSVC 17.9.34728.123; Debug build.
