### PR TITLE
Fix missing headers in Debian package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
     - name: Get cross-platform /dev/null for hidden output
       run: echo "HIDDEN=$(python3 -c "import os; print(os.devnull)")" >> $GITHUB_ENV
 
+    - name: Install pybind11
+      run: git clone --depth 1 --branch v2.13.1 https://github.com/pybind/pybind11.git
+
     - name: Install valgrind
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install -y valgrind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Install package
       working-directory: build
-      run: apt install ./ruckig-*.deb
+      run: sudo apt-get install ./ruckig-*.deb
 
     - name: Test building examples
       working-directory: examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -17,9 +17,6 @@ jobs:
 
     - name: Get cross-platform /dev/null for hidden output
       run: echo "HIDDEN=$(python3 -c "import os; print(os.devnull)")" >> $GITHUB_ENV
-
-    - name: Install pybind11
-      run: git clone --depth 1 --branch v2.13.1 https://github.com/pybind/pybind11.git
 
     - name: Install valgrind
       if: matrix.os == 'ubuntu-latest'
@@ -61,6 +58,29 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         ctest --test-dir ./build -T memcheck
+
+
+  build-package:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure and make
+      run: |
+        cmake -B build
+        cmake --build build -j2 -- package
+
+    - name: Install package
+      working-directory: build
+      run: apt install ./ruckig-*.deb
+
+    - name: Test building examples
+      working-directory: examples
+      run: |
+        mv CMakeLists-installed.txt CMakeLists.txt
+        cmake -B build
+        cmake --build build -j2
 
 
   lint-python:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(BUILD_CLOUD_CLIENT)
   target_sources(ruckig PRIVATE src/ruckig/cloud_client.cpp)
   target_include_directories(ruckig PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ruckig/third_party>
   )
   target_compile_definitions(ruckig PUBLIC WITH_CLOUD_CLIENT)
 endif()
@@ -131,6 +131,9 @@ include(CMakePackageConfigHelpers)
 
 # Install headers
 install(DIRECTORY include/ruckig DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(BUILD_CLOUD_CLIENT)
+  install(DIRECTORY third_party/httplib third_party/nlohmann DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ruckig/third_party)
+endif()
 
 # Install library
 install(TARGETS ruckig

--- a/examples/CMakeLists-directory.txt
+++ b/examples/CMakeLists-directory.txt
@@ -8,7 +8,7 @@ include_directories(include)
 link_directories(lib)
 
 # Build the position example
-add_executable(example-position examples/01_position.cpp)
+add_executable(example-position 01_position.cpp)
 target_compile_features(example-position PUBLIC cxx_std_17)
 
 target_link_libraries(example-position ruckig)

--- a/examples/CMakeLists-installed.txt
+++ b/examples/CMakeLists-installed.txt
@@ -7,7 +7,7 @@ project(ruckig_examples)
 find_package(ruckig REQUIRED)
 
 # Build the position example
-add_executable(example-position examples/01_position.cpp)
+add_executable(example-position 01_position.cpp)
 target_compile_features(example-position PUBLIC cxx_std_17)
 
 target_link_libraries(example-position PRIVATE ruckig::ruckig)


### PR DESCRIPTION
This PR:
 - Adds a CI job to build the package and compile the first example, making sure that all headers are present. Previously, this [has been failing](https://github.com/pantor/ruckig/actions/runs/10727549958) because of missing headers.
 - Installs the missing headers into `include/ruckig/third_party` and adds the corresponding include directory.