### PR TITLE
Fix dynamic allocation in trajectory.hpp

### DIFF
--- a/include/ruckig/trajectory.hpp
+++ b/include/ruckig/trajectory.hpp
@@ -57,8 +57,8 @@ class Trajectory {
 #endif
 
     //! Calculates the base values to then integrate from
-    using SetIntegrate = std::function<void(size_t, double, double, double, double, double)>;
-    void state_to_integrate_from(double time, size_t& new_section, const SetIntegrate& set_integrate) const {
+    template<typename Func>
+    void state_to_integrate_from(double time, size_t& new_section, Func&& set_integrate) const {
         if (time >= duration) {
             // Keep constant acceleration
             new_section = profiles.size();


### PR DESCRIPTION
The lambda to std::function allocates heap memory, not good in a real-time context.
There's better ways to do that in c++20 and up, here is just a quick fix to stay compatible.