### PR TITLE
add at_time overload which accepts lists

### DIFF
--- a/examples/02_position_offline.py
+++ b/examples/02_position_offline.py
@@ -38,5 +38,11 @@ if __name__ == '__main__':
 
     print(f'Position at time {new_time:0.4f} [s]: {new_position}')
 
+    # Or we can pass a list of time values to get the corresponding kinematic states
+    new_times = [0.5, 1.0, 1.5]
+    new_positions, new_velocities, new_accelerations = trajectory.at_time(new_times)
+
+    print(f'Positions at times {new_times[0]:0.4f} {new_times[1]:0.4f} {new_times[2]:0.4f} [s]: {new_positions}')
+
     # Get some info about the position extrema of the trajectory
     print(f'Position extremas are {trajectory.position_extrema}')

--- a/src/ruckig/python.cpp
+++ b/src/ruckig/python.cpp
@@ -77,6 +77,24 @@ limited by velocity, acceleration, and jerk constraints.";
             }
             return py::make_tuple(new_position, new_velocity, new_acceleration);
         }, "time"_a, "return_section"_a=false)
+        .def("at_time", [](const Trajectory<DynamicDOFs>& traj, const py::list& times, bool return_section=false) {
+            std::vector<double> new_position(traj.degrees_of_freedom), new_velocity(traj.degrees_of_freedom), new_acceleration(traj.degrees_of_freedom), new_jerk(traj.degrees_of_freedom);
+            py::list result_position(times.size()), result_velocity(times.size()), result_acceleration(times.size()), result_section(times.size());
+            for (std::size_t i = 0; i < times.size(); i++) {
+                const auto time = times[i].cast<double>();
+                size_t new_section;
+                traj.at_time(time, new_position, new_velocity, new_acceleration, new_jerk, new_section);
+                result_position[i] = new_position;
+                result_velocity[i] = new_velocity;
+                result_acceleration[i] = new_acceleration;
+                result_section[i] = new_section;
+            }
+
+            if (return_section) {
+                return py::make_tuple(result_position, result_velocity, result_acceleration, result_section);
+            }
+            return py::make_tuple(result_position, result_velocity, result_acceleration);
+        }, "times"_a, "return_section"_a=false)
         .def("get_first_time_at_position", [](const Trajectory<DynamicDOFs>& traj, size_t dof, double position) -> py::object {
             double time;
             if (traj.get_first_time_at_position(dof, position, time)) {


### PR DESCRIPTION
Possible solution for #212 . How the output looks like running the script now:

```
Trajectory duration: 3.8796 [s]
Position at time 1.0000 [s]: [0.6388750444233515, -1.1631409505208554, -0.11589549559277784]
Positions at times 0.5000 1.0000 1.5000 [s]: [[0.08333333333333333, -0.8314814814814853, 0.20082986124446606], [0.6388750444233515, -1.1631409505208554, -0.11589549559277784], [1.628943788676886, -1.1407581380208773, -0.4326208524300217]]
Position extremas are [[0.000000, 5.000000], [-2.000000, 0.000000], [-3.500000, 0.500000]]
```