### PR TITLE
fix setuptools deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: C++",
 ]
 requires-python = ">=3.8"


### PR DESCRIPTION
License classifiers are deprecated. !!
license is already set in raw 10
