### PR TITLE
Add ruckig-scl to Used By

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Ruckig is used by over hundred research labs, companies, and open-source project
 - [Gestalt Robotics](https://www.gestalt-robotics.com)
 - [AgiBot Genie Sim](https://github.com/AgibotTech/genie_sim)
 - [Struckig](https://github.com/stefanbesler/struckig), a port of Ruckig to Structered Text (ST - IEC61131-3) for usage on PLCs.
+- [Ruckig-Scl](https://github.com/core-engineering/ruckig-scl), a port of Ruckig to SCL (ST - IEC61131-3) for Siemens PLCs
 - [Frankx](https://github.com/pantor/frankx) for controlling the Franka Emika robot arm.
 - [TidyBot++](https://github.com/jimmyyhwu/tidybot2)
 - [Wiredworks](https://wiredworks.com) made a simple Kivy [GUI application](https://github.com/wiredworks/ruckig-showcase)


### PR DESCRIPTION
Hi,

I've ported the Ruckig Community Version to SCL for the Siemens S7-1500/TIA Portal ecosystem (complementary to Struckig, which targets TwinCAT).

This PR adds it to the "Used By" list. Happy to adjust the wording.

Thanks for Ruckig — great work.

Camille