### PR TITLE
Fix uninitialized parameters

### DIFF
--- a/include/ruckig/input_parameter.hpp
+++ b/include/ruckig/input_parameter.hpp
@@ -43,10 +43,13 @@ class InputParameter {
 
     void initialize() {
         for (size_t dof = 0; dof < degrees_of_freedom; ++dof) {
+            current_position[dof] = 0.0;
             current_velocity[dof] = 0.0;
             current_acceleration[dof] = 0.0;
+            target_position[dof] = 0.0;
             target_velocity[dof] = 0.0;
             target_acceleration[dof] = 0.0;
+            max_velocity[dof] = std::numeric_limits<double>::infinity();
             max_acceleration[dof] = std::numeric_limits<double>::infinity();
             max_jerk[dof] = std::numeric_limits<double>::infinity();
             max_position[dof] = std::numeric_limits<double>::infinity();


### PR DESCRIPTION
Hi,

I noticed that some parameters were uninitialized which meant, when I reset controllers, it would use the same heap address that gets freed up and the old controller values would be used. Here is a simple code snippet that shows the problem:

```

  // First controller: set target_position=5.0 and run a few steps
  auto otg_0 = std::make_unique<ruckig::Ruckig<1>>(0.1);
  auto input_0 = std::make_unique<ruckig::InputParameter<1>>();
  input_0->max_velocity = {2.0};
  input_0->max_acceleration = {4.0};
  input_0->max_jerk = {20.0};
  input_0->target_position = {5.0};
  auto output_0 = std::make_unique<ruckig::OutputParameter<1>>();

  logger_.info("=== First controller (target_pos=5.0) ===");
  for (int i = 0; i < 10; ++i) {
    auto result = otg_0->update(*input_0, *output_0);
    logger_.info(
      "  step {}: pos={:.4f}, vel={:.4f}, acc={:.4f}, result={}", i,
      output_0->new_position[0], output_0->new_velocity[0], output_0->new_acceleration[0],
      static_cast<int>(result));
    output_0->pass_to_input(*input_0);
  }

  // Destroy everything
  otg_0.reset();
  input_0.reset();
  output_0.reset();

  // Second controller: DO NOT set target_position (default should be 0.0)
  // If reset works correctly, it should stay at 0 (already at target).
  // If there's caching, it will move toward 5.0 from the first controller.
  auto otg_1 = std::make_unique<ruckig::Ruckig<1>>(0.1);
  auto input_1 = std::make_unique<ruckig::InputParameter<1>>();
  input_1->max_velocity = {2.0};
  input_1->max_acceleration = {4.0};
  input_1->max_jerk = {20.0};
  // NOTE: intentionally NOT setting target_position here
  auto output_1 = std::make_unique<ruckig::OutputParameter<1>>();

  logger_.info("=== Second controller (NO target set, expect pos=0) ===");
  logger_.info("  input_1->target_position[0] = {:.4f}", input_1->target_position[0]);
  logger_.info("  input_1->current_position[0] = {:.4f}", input_1->current_position[0]);
  for (int i = 0; i < 10; ++i) {
    auto result = otg_1->update(*input_1, *output_1);
    logger_.info(
      "  step {}: pos={:.4f}, vel={:.4f}, acc={:.4f}, result={}", i,
      output_1->new_position[0], output_1->new_velocity[0], output_1->new_acceleration[0],
      static_cast<int>(result));
    output_1->pass_to_input(*input_1);
  }

```

As you can see, in the second controller, the target position for instance is not being set. Same as current position. But if you run this you see that second controller is picking up values from the first controller:

<img width="746" height="678" alt="Screenshot from 2026-06-15 11-34-38" src="https://github.com/user-attachments/assets/79492f69-6141-4630-a915-73a04aaed2dd" />

So with the fix that I am introducing in this PR, everything gets properly initialized and the second controller also acts as expected then:

<img width="579" height="555" alt="Screenshot from 2026-06-15 11-26-36" src="https://github.com/user-attachments/assets/2ab4b064-92f5-4e9a-98c3-f7d82383f7b8" />
