### PR TITLE
Fix build from dependency on latest scikit-build-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ requires = ["scikit-build-core", "nanobind"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-cmake.targets = ["python_ruckig"]
+minimum-version = "0.10"
+build.targets = ["python_ruckig"]
 sdist.exclude = [".github"]
 
 [tool.scikit-build.cmake.define]


### PR DESCRIPTION
scikit-build-core 1.0.0 removed the deprecated `cmake.targets` key, so
`pip install ruckig` now fails at build time with:

    ERROR: Use build.targets instead of cmake.targets for scikit-build-core >= 0.10

Rename to `build.targets` (valid since scikit-build-core 0.10) and set
minimum-version = "0.10" so newer backends select compatible defaults.

This also restores the `build-python-package` CI job, which runs `pip install .`
and currently fails on the same error.

Fixes #261
