### PR TITLE
Fix out-of-bounds writes when Step 1 finds duplicate profiles 

### DIFF
--- a/include/ruckig/block.hpp
+++ b/include/ruckig/block.hpp
@@ -21,6 +21,23 @@ class Block {
         valid_profile_counter -= 1;
     }
 
+    template<size_t N>
+    inline static void remove_duplicate_profiles(std::array<Profile, N>& valid_profiles, size_t& valid_profile_counter) {
+        constexpr double rel_tolerance {256 * std::numeric_limits<double>::epsilon()};
+
+        for (size_t i = 0; i + 1 < valid_profile_counter; ++i) {
+            const double duration = valid_profiles[i].t_sum.back();
+            const double tolerance = rel_tolerance * std::max(1.0, std::abs(duration));
+            for (size_t j = i + 1; j < valid_profile_counter; ) {
+                if (std::abs(valid_profiles[j].t_sum.back() - duration) <= tolerance) {
+                    remove_profile<N>(valid_profiles, valid_profile_counter, j);
+                } else {
+                    ++j;
+                }
+            }
+        }
+    }
+
 public:
     struct Interval {
         double left, right; // [s]
@@ -63,16 +80,13 @@ public:
         //     std::cout << valid_profiles[i].t_sum.back() << " " << valid_profiles[i].to_string() << std::endl;
         // }
 
+        remove_duplicate_profiles<N>(valid_profiles, valid_profile_counter);
+
         if (valid_profile_counter == 1) {
             block.set_min_profile(valid_profiles[0]);
             return true;
 
         } else if (valid_profile_counter == 2) {
-            if (std::abs(valid_profiles[0].t_sum.back() - valid_profiles[1].t_sum.back()) < 8 * std::numeric_limits<double>::epsilon()) {
-                block.set_min_profile(valid_profiles[0]);
-                return true;
-            }
-
             if constexpr (numerical_robust) {
                 const size_t idx_min = (valid_profiles[0].t_sum.back() < valid_profiles[1].t_sum.back()) ? 0 : 1;
                 const size_t idx_else_1 = (idx_min + 1) % 2;
@@ -80,19 +94,6 @@ public:
                 block.set_min_profile(valid_profiles[idx_min]);
                 block.a = Interval(valid_profiles[idx_min], valid_profiles[idx_else_1]);
                 return true;
-            }
-
-        // Only happens due to numerical issues
-        } else if (valid_profile_counter == 4) {
-            // Find "identical" profiles
-            if (std::abs(valid_profiles[0].t_sum.back() - valid_profiles[1].t_sum.back()) < 32 * std::numeric_limits<double>::epsilon() && valid_profiles[0].direction != valid_profiles[1].direction) {
-                remove_profile<N>(valid_profiles, valid_profile_counter, 1);
-            } else if (std::abs(valid_profiles[2].t_sum.back() - valid_profiles[3].t_sum.back()) < 256 * std::numeric_limits<double>::epsilon() && valid_profiles[2].direction != valid_profiles[3].direction) {
-                remove_profile<N>(valid_profiles, valid_profile_counter, 3);
-            } else if (std::abs(valid_profiles[0].t_sum.back() - valid_profiles[3].t_sum.back()) < 256 * std::numeric_limits<double>::epsilon() && valid_profiles[0].direction != valid_profiles[3].direction) {
-                remove_profile<N>(valid_profiles, valid_profile_counter, 3);
-            } else {
-                return false;
             }
 
         } else if (valid_profile_counter % 2 == 0) {

--- a/include/ruckig/position.hpp
+++ b/include/ruckig/position.hpp
@@ -40,6 +40,9 @@ class PositionThirdOrderStep1 {
     bool time_all_single_step(Profile* profile, double vMax, double vMin, double aMax, double aMin, double jMax) const;
 
     inline void add_profile(ProfileIter& profile) const {
+        if (profile + 1 == valid_profiles.cend()) {
+            return;
+        }
         const auto prev_profile = profile;
         ++profile;
         profile->set_boundary(*prev_profile);
@@ -101,8 +104,8 @@ class PositionSecondOrderStep1 {
     double pd;
 
     // Max 3 valid profiles
-    using ProfileIter = std::array<Profile, 3>::iterator;
-    std::array<Profile, 3> valid_profiles;
+    using ProfileIter = std::array<Profile, 4>::iterator;
+    std::array<Profile, 4> valid_profiles;
 
     void time_acc0(ProfileIter& profile, double vMax, double vMin, double aMax, double aMin, bool return_after_found) const;
     void time_none(ProfileIter& profile, double vMax, double vMin, double aMax, double aMin, bool return_after_found) const;
@@ -111,6 +114,9 @@ class PositionSecondOrderStep1 {
     bool time_all_single_step(Profile* profile, double vMax, double vMin, double aMax, double aMin) const;
 
     inline void add_profile(ProfileIter& profile) const {
+        if (profile + 1 == valid_profiles.cend()) {
+            return;
+        }
         const auto prev_profile = profile;
         ++profile;
         profile->set_boundary(*prev_profile);

--- a/include/ruckig/velocity.hpp
+++ b/include/ruckig/velocity.hpp
@@ -18,8 +18,8 @@ class VelocityThirdOrderStep1 {
     double vd;
 
     // Max 3 valid profiles
-    using ProfileIter = std::array<Profile, 3>::iterator;
-    std::array<Profile, 3> valid_profiles;
+    using ProfileIter = std::array<Profile, 4>::iterator;
+    std::array<Profile, 4> valid_profiles;
 
     void time_acc0(ProfileIter& profile, double aMax, double aMin, double jMax, bool return_after_found) const;
     void time_none(ProfileIter& profile, double aMax, double aMin, double jMax, bool return_after_found) const;
@@ -28,6 +28,9 @@ class VelocityThirdOrderStep1 {
     bool time_all_single_step(Profile* profile, double aMax, double aMin, double jMax) const;
 
     inline void add_profile(ProfileIter& profile) const {
+        if (profile + 1 == valid_profiles.cend()) {
+            return;
+        }
         const auto prev_profile = profile;
         ++profile;
         profile->set_boundary(*prev_profile);

--- a/test/test_target.cpp
+++ b/test/test_target.cpp
@@ -1043,6 +1043,47 @@ TEST_CASE("position-second-random-3") {
     }
 }
 
+TEST_CASE("issue-255-stack-smashing") {
+    // https://github.com/pantor/ruckig/issues/255
+    Ruckig<1> otg {0.001};
+    InputParameter<1> input;
+    input.current_position = {1.1032599505208334};
+    input.current_velocity = {0.36337812500000005};
+    input.current_acceleration = {0.8525};
+    input.target_position = {2.9033375720687795};
+    input.target_velocity = {0.3477303818980908};
+    input.target_acceleration = {-0.833942902};
+    input.max_velocity = {1.0};
+    input.max_acceleration = {1.0};
+    input.max_jerk = {1.0};
+
+    Trajectory<1> trajectory;
+    CHECK( otg.calculate(input, trajectory) == Result::Working );
+
+    // The variant that used to smash the stack: one ULP down on p0.
+    input.current_position = {1.103259950520833};
+    CHECK( otg.calculate(input, trajectory) == Result::Working );
+}
+
+TEST_CASE("issue-216-short-trajectory-out-of-range") {
+    // https://github.com/pantor/ruckig/issues/216
+    Ruckig<1> otg {0.001};
+    InputParameter<1> input;
+    input.current_position = {0.0};
+    input.current_velocity = {0.0};
+    input.current_acceleration = {0.0};
+    input.target_position = {1e-6};
+    input.target_velocity = {0.0};
+    input.target_acceleration = {0.0};
+    input.max_velocity = {1.0};
+    input.max_acceleration = {1.0};
+    input.max_jerk = {1.0};
+
+    Trajectory<1> trajectory;
+    CHECK( otg.calculate(input, trajectory) == Result::Working );
+}
+
+
 
 int main(int argc, char** argv) {
     doctest::Context context;


### PR DESCRIPTION
Fixes stack buffer overflow / memory corruption and "error in step 1" failures when Step 1 finds duplicate candidate profiles near boundary conditions (Fixes #255, Fixes #216, supersedes #189).
    
1. Bounds check in `add_profile()`  to prevent writing past `valid_profiles.end()` when duplicate profiles are found.
2. Sized `valid_profiles` to 4 in `PositionSecondOrderStep1` and `VelocityThirdOrderStep1` to accommodate the scratch evaluation slot.
3. Duplicate merging: Merged duplicates in `Block::calculate_block` using a relative duration tolerance (`256 * DBL_EPSILON`). This part of the fix was also in #123 (https://github.com/Fubini2/ruckig/commit/cf9d03edebb09d6041b6244ef19bf0e4fa82860b), I just tightened it up and made reviewable (hopefully)
4. Tests: Added regression unit tests for #255 and #216 in `test/test_target.cpp`.